### PR TITLE
Introduce get_part_ref() and migrate primary use to .get_part()

### DIFF
--- a/cas/grpc_service/bytestream_server.rs
+++ b/cas/grpc_service/bytestream_server.rs
@@ -244,7 +244,7 @@ impl ByteStreamServer {
 
         let digest = DigestInfo::try_new(resource_info.hash, resource_info.expected_size)?;
 
-        let (mut tx, rx) = buf_channel::make_buf_channel_pair();
+        let (tx, rx) = buf_channel::make_buf_channel_pair();
 
         struct ReaderState {
             max_bytes_per_stream: usize,
@@ -262,7 +262,7 @@ impl ByteStreamServer {
             maybe_get_part_result: None,
             get_part_fut: Box::pin(async move {
                 store
-                    .get_part_arc(digest, &mut tx, read_request.read_offset as usize, read_limit)
+                    .get_part_arc(digest, tx, read_request.read_offset as usize, read_limit)
                     .await
             }),
         });

--- a/cas/store/dedup_store.rs
+++ b/cas/store/dedup_store.rs
@@ -217,7 +217,7 @@ impl StoreTrait for DedupStore {
         Ok(())
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,

--- a/cas/store/filesystem_store.rs
+++ b/cas/store/filesystem_store.rs
@@ -619,7 +619,7 @@ impl<Fe: FileEntry> StoreTrait for FilesystemStore<Fe> {
             .err_tip(|| format!("While processing with temp file {:?}", temp_full_path))
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,

--- a/cas/store/grpc_store.rs
+++ b/cas/store/grpc_store.rs
@@ -567,7 +567,7 @@ impl StoreTrait for GrpcStore {
         Ok(())
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,

--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -106,7 +106,7 @@ impl StoreTrait for MemoryStore {
         Ok(())
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,

--- a/cas/store/ref_store.rs
+++ b/cas/store/ref_store.rs
@@ -110,7 +110,7 @@ impl StoreTrait for RefStore {
         Pin::new(store.as_ref()).update(digest, reader, size_info).await
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -118,7 +118,9 @@ impl StoreTrait for RefStore {
         length: Option<usize>,
     ) -> Result<(), Error> {
         let store = self.get_store()?;
-        Pin::new(store.as_ref()).get_part(digest, writer, offset, length).await
+        Pin::new(store.as_ref())
+            .get_part_ref(digest, writer, offset, length)
+            .await
     }
 
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {

--- a/cas/store/s3_store.rs
+++ b/cas/store/s3_store.rs
@@ -413,7 +413,7 @@ impl StoreTrait for S3Store {
         complete_result
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,

--- a/cas/store/size_partitioning_store.rs
+++ b/cas/store/size_partitioning_store.rs
@@ -98,7 +98,7 @@ impl StoreTrait for SizePartitioningStore {
             .await
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
@@ -107,11 +107,11 @@ impl StoreTrait for SizePartitioningStore {
     ) -> Result<(), Error> {
         if digest.size_bytes < self.size {
             return Pin::new(self.lower_store.as_ref())
-                .get_part(digest, writer, offset, length)
+                .get_part_ref(digest, writer, offset, length)
                 .await;
         }
         Pin::new(self.upper_store.as_ref())
-            .get_part(digest, writer, offset, length)
+            .get_part_ref(digest, writer, offset, length)
             .await
     }
 

--- a/cas/store/tests/filesystem_store_test.rs
+++ b/cas/store/tests/filesystem_store_test.rs
@@ -350,10 +350,10 @@ mod filesystem_store_tests {
         // Insert data into store.
         store_pin.as_ref().update_oneshot(digest1, VALUE1.into()).await?;
 
-        let (mut writer, mut reader) = make_buf_channel_pair();
+        let (writer, mut reader) = make_buf_channel_pair();
         let store_clone = store.clone();
         let digest1_clone = digest1;
-        tokio::spawn(async move { Pin::new(store_clone.as_ref()).get(digest1_clone, &mut writer).await });
+        tokio::spawn(async move { Pin::new(store_clone.as_ref()).get(digest1_clone, writer).await });
 
         {
             // Check to ensure our first byte has been received. The future should be stalled here.
@@ -455,9 +455,9 @@ mod filesystem_store_tests {
         store_pin.as_ref().update_oneshot(digest1, VALUE1.into()).await?;
 
         let mut reader = {
-            let (mut writer, reader) = make_buf_channel_pair();
+            let (writer, reader) = make_buf_channel_pair();
             let store_clone = store.clone();
-            tokio::spawn(async move { Pin::new(store_clone.as_ref()).get(digest1, &mut writer).await });
+            tokio::spawn(async move { Pin::new(store_clone.as_ref()).get(digest1, writer).await });
             reader
         };
         // Ensure we have received 1 byte in our buffer. This will ensure we have a reference to

--- a/cas/store/verify_store.rs
+++ b/cas/store/verify_store.rs
@@ -151,14 +151,14 @@ impl StoreTrait for VerifyStore {
         update_res.merge(check_res)
     }
 
-    async fn get_part(
+    async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,
         writer: &mut DropCloserWriteHalf,
         offset: usize,
         length: Option<usize>,
     ) -> Result<(), Error> {
-        self.pin_inner().get_part(digest, writer, offset, length).await
+        self.pin_inner().get_part_ref(digest, writer, offset, length).await
     }
 
     fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {


### PR DESCRIPTION
Due to DropCloserWriteHalf being so fragile in how it is dropped, it was decided that we should prefer to pass an owned version to the store api and introduce `.get_part_ref()` to handle cases where the writer should not be dropped on the return.

This will protect from cases where users join!() the reader and writer sides, but a deadlock happens because the writer errors but doesn't drop, notifying the reader side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/292)
<!-- Reviewable:end -->
