### PR TITLE
Always make a copy in MemoryStore to reduce long-lasting allocs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ dependencies = [
 name = "memory_store_test"
 version = "0.0.0"
 dependencies = [
+ "bytes",
  "common",
  "config",
  "error",

--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -372,12 +372,16 @@ rust_test(
 rust_test(
     name = "memory_store_test",
     srcs = ["tests/memory_store_test.rs"],
+    env = {
+        "RUST_TEST_THREADS": "1", # This test can't run in parallel.
+    },
     deps = [
         ":memory_store",
         ":traits",
         "//config",
         "//util:common",
         "//util:error",
+        "@crate_index//:bytes",
         "@crate_index//:pretty_assertions",
         "@crate_index//:tokio",
     ],

--- a/gencargo/memory_store_test/Cargo.toml
+++ b/gencargo/memory_store_test/Cargo.toml
@@ -19,6 +19,7 @@ path = "../../cas/store/tests/memory_store_test.rs"
 doctest = false
 
 [dependencies]
+bytes = { workspace = true }
 pretty_assertions = { workspace = true }
 tokio = { workspace = true }
 


### PR DESCRIPTION
possibly fix: #289

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/294)
<!-- Reviewable:end -->
