### PR TITLE
Make update_protos test compatible with Windows

### DIFF
--- a/proto/update_protos.py
+++ b/proto/update_protos.py
@@ -78,7 +78,8 @@ def check(proto_packages):
             failed = True
             print("Could not read package %s: %s" % (pkg, e))
             continue
-        if expected == actual:
+        # Ignore differences between newlines on Unix and Windows.
+        if expected.splitlines() == actual.splitlines():
             print("%s OK" % dst)
         else:
             print("%s out of date" % dst)
@@ -94,7 +95,8 @@ def check(proto_packages):
     except OSError as e:
         failed = True
         print("Could not read package lib.rs: %s" % e)
-    if expected == actual:
+    # Ignore differences between newlines on Unix and Windows.
+    if expected.splitlines() == actual.splitlines():
         print("%s OK" % dst)
     else:
         print("%s out of date" % dst)


### PR DESCRIPTION
The previous variant didn't account for different newline encodings on Unix and Windows. This wasn't (and still isn't) visible in CI because the Windows workflow only invokes Cargo tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/314)
<!-- Reviewable:end -->
