### PR TITLE
Globally enable windows symlinks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,6 +51,6 @@ build:tsan --cache_test_results=no
 build:tsan --run_under=//tools:tsan.sh
 
 # Configuration options for Windows builds.
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --cxxopt=/std:c++14 --host_cxxopt=/std:c++14
 build:windows --enable_runfiles


### PR DESCRIPTION
Turns out that `startup:someconfig` is invalid syntax. Since the flag only applies to Windows it's safe to make it global.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/327)
<!-- Reviewable:end -->
