### PR TITLE
Close on complete in GrpcScheduler

### DIFF
--- a/cas/scheduler/grpc_scheduler.rs
+++ b/cas/scheduler/grpc_scheduler.rs
@@ -66,7 +66,12 @@ impl GrpcScheduler {
                             log::info!("Client disconnected in GrpcScheduler");
                             return;
                         }
-                        Ok(Some(response)) = result_stream.message() => {
+                        response = result_stream.message() => {
+                            // When the upstream closes the channel, close the
+                            // downstream too.
+                            let Ok(Some(response)) = response else {
+                                return;
+                            };
                             match response.try_into() {
                                 Ok(response) => {
                                     if let Err(err) = tx.send(Arc::new(response)) {


### PR DESCRIPTION
# Description

The GrpcScheduler fails to close the downstream Receiver when the upstream one completes.  This causes it to hang forever even though its completed.

Fixes #323

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Using a GrpcScheduler in front of a SimpleScheduler to a Reclient.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/328)
<!-- Reviewable:end -->
