### PR TITLE
Removed response message and set to empty string

### DIFF
--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -337,7 +337,7 @@ pub mod execution_response_tests {
                     details: Default::default(),
                 }),
                 server_logs,
-                message: "TODO(blaise.bruer) We should put a reference something like bb_browser".to_string(),
+                message: String::new(),
             })),
         };
         {

--- a/cas/scheduler/action_messages.rs
+++ b/cas/scheduler/action_messages.rs
@@ -685,7 +685,6 @@ impl From<&ActionStage> for execution_stage::Value {
 
 impl From<ActionStage> for ExecuteResponse {
     fn from(val: ActionStage) -> Self {
-        const RESPONSE_MESSAGE: &str = "TODO(blaise.bruer) We should put a reference something like bb_browser";
 
         fn logs_from(server_logs: HashMap<String, DigestInfo>) -> HashMap<String, LogFile> {
             let mut logs = HashMap::with_capacity(server_logs.len());
@@ -714,7 +713,7 @@ impl From<ActionStage> for ExecuteResponse {
                     result: Some(action_result.into()),
                     cached_result: false,
                     status,
-                    message: RESPONSE_MESSAGE.to_string(),
+                    message: String::new(),
                 }
             }
             // Handled separately as there are no server logs and the action
@@ -724,7 +723,7 @@ impl From<ActionStage> for ExecuteResponse {
                 result: Some(proto_action_result),
                 cached_result: true,
                 status: Some(Status::default()),
-                message: RESPONSE_MESSAGE.to_string(),
+                message: String::new(),
             },
         }
     }


### PR DESCRIPTION
Response message needs to just be an empty string as it shows on every failure for TWA.

Fixes #331

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/332)
<!-- Reviewable:end -->
