### PR TITLE
Implementing tree traversal for pruning stale actions

### DIFF
--- a/cas/store/compression_store.rs
+++ b/cas/store/compression_store.rs
@@ -365,6 +365,13 @@ impl StoreTrait for CompressionStore {
         write_result.merge(update_result)
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/dedup_store.rs
+++ b/cas/store/dedup_store.rs
@@ -217,6 +217,13 @@ impl StoreTrait for DedupStore {
         Ok(())
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/fast_slow_store.rs
+++ b/cas/store/fast_slow_store.rs
@@ -189,6 +189,13 @@ impl StoreTrait for FastSlowStore {
         Ok(())
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/filesystem_store.rs
+++ b/cas/store/filesystem_store.rs
@@ -622,6 +622,13 @@ impl<Fe: FileEntry> StoreTrait for FilesystemStore<Fe> {
             .err_tip(|| format!("While processing with temp file {:?}", temp_full_path))
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -104,6 +104,13 @@ impl StoreTrait for MemoryStore {
         Ok(())
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/ref_store.rs
+++ b/cas/store/ref_store.rs
@@ -110,6 +110,13 @@ impl StoreTrait for RefStore {
         Pin::new(store.as_ref()).update(digest, reader, size_info).await
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/shard_store.rs
+++ b/cas/store/shard_store.rs
@@ -152,6 +152,13 @@ impl StoreTrait for ShardStore {
             .err_tip(|| "In ShardStore::update()")
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/size_partitioning_store.rs
+++ b/cas/store/size_partitioning_store.rs
@@ -98,6 +98,13 @@ impl StoreTrait for SizePartitioningStore {
             .await
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/store/store_trait.rs
+++ b/cas/store/store_trait.rs
@@ -77,6 +77,13 @@ pub trait StoreTrait: Sync + Send + Unpin {
         upload_size: UploadSizeInfo,
     ) -> Result<(), Error>;
 
+    /// Delete a digest from the store.
+    /// If the digest does not exist in the store, return Ok(()).
+    async fn delete(
+        self: Pin<&Self>,
+        digest: DigestInfo,
+    ) -> Result<(), Error>;
+
     // Utility to send all the data to the store when you have all the bytes.
     async fn update_oneshot(self: Pin<&Self>, digest: DigestInfo, data: Bytes) -> Result<(), Error> {
         // TODO(blaise.bruer) This is extremely inefficient, since we have exactly

--- a/cas/store/verify_store.rs
+++ b/cas/store/verify_store.rs
@@ -151,6 +151,13 @@ impl StoreTrait for VerifyStore {
         update_res.merge(check_res)
     }
 
+    async fn delete(
+        self: Pin<&Self>,
+        _digest: DigestInfo,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     async fn get_part_ref(
         self: Pin<&Self>,
         digest: DigestInfo,

--- a/cas/worker/running_actions_manager.rs
+++ b/cas/worker/running_actions_manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Turbo Cache Authors. All rights reserved.
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -482,6 +482,30 @@ impl RunningActionImpl {
             did_cleanup: AtomicBool::new(false),
         }
     }
+   
+    async fn find_and_del_stale_actions(self: Arc<Self>, ac_store: Arc<dyn Store + Send + Sync>, stale_treshold: Arc<i64>, digests: Arc<Vec<DigestInfo>>) -> Result<Vec<DigestInfo>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        
+        let mut stale_digests = Vec::new();
+        let now = SystemTime::now();
+
+        for digest in &*digests {
+            //Decode the digest into an ActionResult using get_and_decode_digest::
+            let action_result = get_and_decode_digest::<ActionResult>(ac_store.clone(), &digest).await?;
+
+            //Get timestamp of completion from Action metadata and compare to current time
+            let completion_time = action_result.execution_metadata.completion_timestamp;
+            if now.duration_since(completion_time)? > stale_treshold {
+                //If it happened too long ago add the digest to a list of stale digests
+                stale_digests.push(digest);
+
+                // Also delete the digest from the Action Cache
+                ac_store.delete(digest).await?;
+            }
+        }
+
+        //return list of stale digests
+        Ok(stale_digests)
+    } 
 
     fn metrics(&self) -> &Arc<Metrics> {
         &self.running_actions_manager.metrics
@@ -1080,6 +1104,8 @@ pub trait RunningActionsManager: Sync + Send + Sized + Unpin + 'static {
 
     async fn kill_all(&self);
 
+    async fn find_stale_build_actions(root_action: Arc<RunningActionImpl>, ac_store: Arc<dyn Store + Send + Sync>) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
+
     fn metrics(&self) -> &Arc<Metrics>;
 }
 
@@ -1128,7 +1154,8 @@ pub struct RunningActionsManagerImpl {
     // Note: We don't use Notify because we need to support a .wait_for()-like function, which
     // Notify does not support.
     action_done_tx: watch::Sender<()>,
-    callbacks: Callbacks,
+    callbacks: Callbacks, 
+    find_stale_build_actions: Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>,
     metrics: Arc<Metrics>,
 }
 
@@ -1162,6 +1189,7 @@ impl RunningActionsManagerImpl {
             running_actions: Mutex::new(HashMap::new()),
             action_done_tx,
             callbacks,
+            find_stale_build_actions: Ok(()),
             metrics: Arc::new(Metrics::default()),
         })
     }
@@ -1250,7 +1278,7 @@ impl RunningActionsManagerImpl {
                 log::error!("Error sending kill to running action {}", hex::encode(action.action_id));
             }
         }
-    }
+    }   
 }
 
 #[async_trait]
@@ -1393,11 +1421,22 @@ impl RunningActionsManager for RunningActionsManagerImpl {
             .subscribe()
             .wait_for(|_| self.running_actions.lock().is_empty())
             .await;
-    }
+    }   
 
     #[inline]
     fn metrics(&self) -> &Arc<Metrics> {
         &self.metrics
+    }
+
+    async fn find_stale_build_actions(root_action: Arc<RunningActionImpl>, ac_store: Arc<dyn Store + Send + Sync>) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        let mut stale_digests: Vec<DigestInfo> = Vec::new();
+        // Your code to populate digest_infos goes here
+        
+        // Store these in a Vec
+        stale_digests = root_action.find_and_del_stale_actions(ac_store, stale_treshold, stale_digests).await?;
+
+        // Remove stale actions
+        Ok(stale_digests)
     }
 }
 


### PR DESCRIPTION
# Description

CAS needs to be pruned of stale actions

Approach:
- In the running_actions_manager, iterate through all of the actions in ac_store and determine whether an action is stale using it's metadata if it was run longer ago than the threshold. 
     - This requires adding functionality to iterate through stores, holding off on implementing unless necessary to 
     implement in all stores.
- After iterating collect the list of just the stale actions
- In cas_server do a DFS walk through the tree using the root_node found with get_tree
     - While walking tree, compare the stale actions list to the digest in the tree, if the digest in the tree is contained in the 
     list of stale actions then remove it from the tree.

Fixes #329

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
- Testing that all actions in the action cache are found
     - Assume it's in a file for simplicity
- Testing that all stale actions in the action cache are found
- Testing that DFS walk down the tree works properly
- Test that removing stale digests from the tree is working and that the 
     - Account for touching anything in the cas re-promote it to the top of the queue.

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/340)
<!-- Reviewable:end -->
