### PR TITLE
Add optimistic channels

### DIFF
--- a/cas/store/s3_store.rs
+++ b/cas/store/s3_store.rs
@@ -110,10 +110,7 @@ where
         // HTTP-level errors. Sometimes can retry.
         Err(RusotoError::Unknown(e)) => match e.status {
             StatusCode::NOT_FOUND => RetryResult::Err(make_err!(Code::NotFound, "{}", e.status.to_string())),
-            StatusCode::INTERNAL_SERVER_ERROR => {
-                RetryResult::Retry(make_err!(Code::Unavailable, "{}", e.status.to_string()))
-            }
-            StatusCode::SERVICE_UNAVAILABLE => {
+            StatusCode::INTERNAL_SERVER_ERROR | StatusCode::SERVICE_UNAVAILABLE => {
                 RetryResult::Retry(make_err!(Code::Unavailable, "{}", e.status.to_string()))
             }
             StatusCode::CONFLICT => RetryResult::Retry(make_err!(Code::Unavailable, "{}", e.status.to_string())),
@@ -153,7 +150,7 @@ impl S3Store {
             S3Client::new_with(dispatcher, credentials_provider, region)
         };
         let jitter_amt = config.retry.jitter;
-        S3Store::new_with_client_and_jitter(
+        Self::new_with_client_and_jitter(
             config,
             s3_client,
             Box::new(move |delay: Duration| {
@@ -172,12 +169,12 @@ impl S3Store {
         s3_client: S3Client,
         jitter_fn: Box<dyn Fn(Duration) -> Duration + Send + Sync>,
     ) -> Result<Self, Error> {
-        Ok(S3Store {
+        Ok(Self {
             s3_client: Arc::new(s3_client),
             bucket: config.bucket.to_string(),
-            key_prefix: config.key_prefix.as_ref().unwrap_or(&"".to_string()).to_owned(),
+            key_prefix: config.key_prefix.as_ref().unwrap_or(&String::new()).clone(),
             jitter_fn,
-            retry: config.retry.to_owned(),
+            retry: config.retry.clone(),
             retrier: Retrier::new(Box::new(|duration| Box::pin(sleep(duration)))),
         })
     }
@@ -196,8 +193,8 @@ impl S3Store {
                 retry_config,
                 unfold((), move |state| async move {
                     let head_req = HeadObjectRequest {
-                        bucket: self.bucket.to_owned(),
-                        key: s3_path.to_owned(),
+                        bucket: self.bucket.clone(),
+                        key: s3_path.clone(),
                         ..Default::default()
                     };
 
@@ -267,8 +264,7 @@ impl StoreTrait for S3Store {
         let s3_path = &self.make_s3_path(&digest);
 
         let max_size = match upload_size {
-            UploadSizeInfo::ExactSize(sz) => sz,
-            UploadSizeInfo::MaxSize(sz) => sz,
+            UploadSizeInfo::ExactSize(sz) | UploadSizeInfo::MaxSize(sz) => sz,
         };
         // NOTE(blaise.bruer) It might be more optimal to use a different heuristic here, but for
         // simplicity we use a hard codded value. Anything going down this if-statement will have
@@ -296,8 +292,8 @@ impl StoreTrait for S3Store {
             };
 
             let put_object_request = PutObjectRequest {
-                bucket: self.bucket.to_owned(),
-                key: s3_path.to_owned(),
+                bucket: self.bucket.clone(),
+                key: s3_path.clone(),
                 content_length,
                 body,
                 ..Default::default()
@@ -317,8 +313,8 @@ impl StoreTrait for S3Store {
         let response = self
             .s3_client
             .create_multipart_upload(CreateMultipartUploadRequest {
-                bucket: self.bucket.to_owned(),
-                key: s3_path.to_owned(),
+                bucket: self.bucket.clone(),
+                key: s3_path.clone(),
                 ..Default::default()
             })
             .await
@@ -349,8 +345,8 @@ impl StoreTrait for S3Store {
                 let body = Some(ByteStream::new(ReaderStream::new(Cursor::new(write_buf))));
 
                 let request = UploadPartRequest {
-                    bucket: self.bucket.to_owned(),
-                    key: s3_path.to_owned(),
+                    bucket: self.bucket.clone(),
+                    key: s3_path.clone(),
                     content_length: Some(write_buf_len),
                     body,
                     part_number,
@@ -383,8 +379,8 @@ impl StoreTrait for S3Store {
             let completed_parts = try_join_all(completed_part_futs).await?;
             self.s3_client
                 .complete_multipart_upload(CompleteMultipartUploadRequest {
-                    bucket: self.bucket.to_owned(),
-                    key: s3_path.to_owned(),
+                    bucket: self.bucket.clone(),
+                    key: s3_path.clone(),
                     upload_id: upload_id.clone(),
                     multipart_upload: Some(CompletedMultipartUpload {
                         parts: Some(completed_parts),
@@ -400,8 +396,8 @@ impl StoreTrait for S3Store {
             let abort_result = self
                 .s3_client
                 .abort_multipart_upload(AbortMultipartUploadRequest {
-                    bucket: self.bucket.to_owned(),
-                    key: s3_path.to_owned(),
+                    bucket: self.bucket.clone(),
+                    key: s3_path.clone(),
                     upload_id: upload_id.clone(),
                     ..Default::default()
                 })
@@ -429,6 +425,11 @@ impl StoreTrait for S3Store {
             .map(|d| (self.jitter_fn)(d))
             .take(self.retry.max_retries); // Remember this is number of retries, so will run max_retries + 1.
 
+        // S3 drops connections when a stream is done. This means that we can't
+        // run the EOF error check. It's safe to disable it since S3 can be
+        // trusted to handle incomplete data properly.
+        writer.set_ignore_eof();
+
         self.retrier
             .retry(
                 retry_config,
@@ -436,12 +437,12 @@ impl StoreTrait for S3Store {
                     let result = self
                         .s3_client
                         .get_object(GetObjectRequest {
-                            bucket: self.bucket.to_owned(),
-                            key: s3_path.to_owned(),
+                            bucket: self.bucket.clone(),
+                            key: s3_path.clone(),
                             range: Some(format!(
                                 "bytes={}-{}",
                                 offset + writer.get_bytes_written() as usize,
-                                end_read_byte.map_or_else(|| "".to_string(), |v| v.to_string())
+                                end_read_byte.map_or_else(String::new, |v| v.to_string())
                             )),
                             ..Default::default()
                         })


### PR DESCRIPTION
This variation on make_buf_channel_pair omits the EOF check. This works around the fact that S3 drops connections as soon as all data is sent or received.

Fixes #304 and fixes the same issue for non-oneshot cases where a similar issue occurred as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/341)
<!-- Reviewable:end -->
