### PR TITLE
Fixed flakiness in integration tests

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -102,6 +102,12 @@ for pattern in "${TEST_PATTERNS[@]}"; do
     FILENAME=$(basename $fullpath)
     echo "Running test $FILENAME"
     sudo docker-compose up -d
+    if perl -e 'alarm shift; exec @ARGV' 30 bash -c 'until sudo docker-compose logs | grep -q "Ready, listening on"; do sleep 1; done'    
+    then
+      echo "String 'Ready, listening on' found in the logs."
+    else
+      echo "String 'Ready, listening on' not found in the logs within the given time."
+    fi
     set +e
     bash -euo pipefail "$fullpath"
     EXIT_CODE="$?"


### PR DESCRIPTION
Added server readiness string listening to integration tests to reduce flakiness

# Description

Listens for string from docker-compose logs to indicate that the servers are ready and listening before running integration tests.

Fixes #375 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran all tests individually and together. TLS test was flaky when running with all tests before change and had no failed runs afterwards.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/378)
<!-- Reviewable:end -->
