### PR TITLE
Added completeness checking store

### DIFF
--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -126,17 +126,42 @@ rust_library(
 )
 
 rust_library(
+    name = "completeness_checking_store",
+    srcs = ["completeness_checking_store.rs"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
+    visibility = ["//cas:__pkg__"],
+    deps = [
+        ":traits",
+        ":ac_utils",
+        "//proto",
+        "//config",
+        "//util:buf_channel",
+        "//util:common",
+        "//util:error",
+        "//util:metrics_utils",
+        "@crate_index//:futures",
+        "@crate_index//:hashbrown",
+        "@crate_index//:hex",
+        "@crate_index//:sha2",
+        "@crate_index//:tokio",
+    ],
+)
+
+rust_library(
     name = "verify_store",
     srcs = ["verify_store.rs"],
     proc_macro_deps = ["@crate_index//:async-trait"],
     visibility = ["//cas:__pkg__"],
     deps = [
         ":traits",
+        ":ac_utils",
+        "//proto",
         "//config",
         "//util:buf_channel",
         "//util:common",
         "//util:error",
         "//util:metrics_utils",
+        "@crate_index//:hashbrown",
         "@crate_index//:hex",
         "@crate_index//:sha2",
         "@crate_index//:tokio",
@@ -383,6 +408,23 @@ rust_test(
         "//util:error",
         "@crate_index//:bytes",
         "@crate_index//:memory-stats",
+        "@crate_index//:pretty_assertions",
+        "@crate_index//:tokio",
+    ],
+)
+
+rust_test(
+    name = "completeness_checking_store_test",
+    srcs = ["tests/completeness_checking_store_test.rs"],
+    deps = [
+        ":memory_store",
+        ":traits",
+        ":completeness_checking_store",
+        "//config",
+        "//util:buf_channel",
+        "//util:common",
+        "//util:error",
+        "@crate_index//:futures",
         "@crate_index//:pretty_assertions",
         "@crate_index//:tokio",
     ],

--- a/cas/store/completeness_checking_store.rs
+++ b/cas/store/completeness_checking_store.rs
@@ -1,0 +1,130 @@
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use hashbrown::HashSet;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use ac_utils::get_and_decode_digest;
+use async_trait::async_trait;
+use proto::build::bazel::remote::execution::v2::Directory;
+
+use buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
+use common::DigestInfo;
+use error::{Code, Error, ResultExt};
+use traits::{StoreTrait, UploadSizeInfo};
+
+pub struct CompletenessCheckingStore {
+    inner_store: Arc<dyn StoreTrait>,
+    completeness_cache: Arc<Mutex<HashSet<DigestInfo>>>,
+}
+
+impl CompletenessCheckingStore {
+    pub fn new(inner_store: Arc<dyn StoreTrait>) -> Self {
+        CompletenessCheckingStore {
+            inner_store,
+            completeness_cache: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    pub async fn find_in_cas(self: Pin<&Self>, digest: DigestInfo) -> Result<(), Error> {
+        let inner_store = self.pin_inner();
+        let mut stack = vec![digest];
+        while let Some(digest) = stack.pop() {
+            let directory = get_and_decode_digest::<Directory>(inner_store, &digest).await?;
+
+            for file in &directory.files {
+                let file_digest = DigestInfo::try_new(
+                    file.digest.as_ref().map_or("", |d| &d.hash),
+                    file.digest.as_ref().map_or(0, |d| d.size_bytes),
+                )?;
+                let exists_in_cache = {
+                    let lock = self.completeness_cache.lock().unwrap();
+                    lock.contains(&file_digest)
+                };
+                if !exists_in_cache {
+                    let exists = self
+                        .pin_inner()
+                        .has(file_digest)
+                        .await
+                        .err_tip(|| "Failed to check file existence in CAS")?;
+                    if let Some(_) = exists {
+                        let mut lock = self.completeness_cache.lock().unwrap();
+                        lock.insert(file_digest);
+                    }
+                }
+            }
+
+            for child_directory in &directory.directories {
+                let child_digest = child_directory.digest.as_ref().map_or_else(
+                    || Err(Error::new(Code::Internal, "Digest is None".to_string())),
+                    |digest| DigestInfo::try_new(&digest.hash.clone(), digest.size_bytes as usize).map_err(Error::from),
+                )?;
+                stack.push(child_digest);
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn has_in_cache(&self, digest: &DigestInfo) -> bool {
+        match self.completeness_cache.lock() {
+            Ok(cache) => cache.contains(digest),
+            Err(_) => false,
+        }
+    }
+
+    fn pin_inner(&self) -> Pin<&dyn StoreTrait> {
+        Pin::new(self.inner_store.as_ref())
+    }
+}
+
+#[async_trait]
+impl StoreTrait for CompletenessCheckingStore {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
+        for (i, digest) in digests.iter().enumerate() {
+            if self.find_in_cas(*digest).await.is_err() {
+                results[i] = None;
+            }
+        }
+
+        self.pin_inner().has_with_results(digests, results).await
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        digest: DigestInfo,
+        reader: DropCloserReadHalf,
+        size_info: UploadSizeInfo,
+    ) -> Result<(), Error> {
+        self.pin_inner().update(digest, reader, size_info).await
+    }
+
+    async fn get_part_ref(
+        self: Pin<&Self>,
+        digest: DigestInfo,
+        writer: &mut DropCloserWriteHalf,
+        offset: usize,
+        length: Option<usize>,
+    ) -> Result<(), Error> {
+        self.pin_inner().get_part_ref(digest, writer, offset, length).await
+    }
+
+    fn as_any(self: Arc<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(self)
+    }
+}

--- a/cas/store/tests/completeness_checking_store_test.rs
+++ b/cas/store/tests/completeness_checking_store_test.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+#[cfg(test)]
+mod completeness_checking_store_tests {
+    use super::*;
+
+    use common::DigestInfo;
+    use completeness_checking_store::CompletenessCheckingStore;
+    use error::Error;
+    use memory_store::MemoryStore;
+    use traits::StoreTrait;
+
+    const VALID_HASH1: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+
+    #[tokio::test]
+    async fn verify_has_with_results_and_find_in_cas() -> Result<(), Error> {
+        let inner_store = Arc::new(MemoryStore::new(&config::stores::MemoryStore::default()));
+        let store_owned = CompletenessCheckingStore::new(inner_store.clone());
+        let pinned_store = Pin::new(&store_owned);
+
+        const VALUE1: &str = "123";
+        let digest = DigestInfo::try_new(VALID_HASH1, 100).unwrap();
+        let result = pinned_store.update_oneshot(digest, VALUE1.into()).await;
+        assert_eq!(result, Ok(()), "Expected success, got: {:?}", result);
+
+        let digest = DigestInfo::try_new(VALID_HASH1, 0).unwrap();
+        let _res = pinned_store.find_in_cas(digest).await;
+        assert!(_res.is_ok(), "Expected find_in_cas to succeed");
+
+        let mut results = vec![Some(0); 1];
+        let _res = pinned_store.has_with_results(&[digest], &mut results).await;
+        assert!(_res.is_ok(), "Expected has_with_results to succeed");
+        assert_eq!(results[0], None, "Expected digest to be pruned from results");
+
+        Ok(())
+    }
+}

--- a/config/stores.rs
+++ b/config/stores.rs
@@ -44,6 +44,8 @@ pub enum StoreConfig {
     /// hash and size and the AC validate nothing.
     verify(Box<VerifyStore>),
 
+    completeness_checking(Box<CompletenessCheckingStore>),
+
     /// A compression store that will compress the data inbound and
     /// outbound. There will be a non-trivial cost to compress and
     /// decompress the data, but in many cases if the final store is
@@ -280,6 +282,9 @@ pub struct DedupStore {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompletenesscheckingStore {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct VerifyStore {
     /// The underlying store wrap around. All content will first flow
     /// through self before forwarding to backend. In the event there
@@ -301,6 +306,16 @@ pub struct VerifyStore {
     /// This should be set to false for AC, but true for CAS stores.
     #[serde(default)]
     pub verify_hash: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompletenessCheckingStore {
+    /// The underlying store wrap around. All content will first flow
+    /// through self before forwarding to backend. In the event there
+    /// is an error detected in self, the connection to the backend
+    /// will be terminated, and early termination should always cause
+    /// updates to fail on the backend.
+    pub backend: StoreConfig,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Copy)]


### PR DESCRIPTION
# Description
Added a completeness checking store to verify all referenced items exist in the CAS before forwarding the items.

Fixes #362 #358

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Tests whether the CAS tree walk works
- Tests whether the CAS tree walk caches when an item exists in the CAS to optimize later checks

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/386)
<!-- Reviewable:end -->
