### PR TITLE
Fix the typo of WorkerProperty

### DIFF
--- a/cas/worker/tests/local_worker_test.rs
+++ b/cas/worker/tests/local_worker_test.rs
@@ -31,7 +31,7 @@ use tonic::Response;
 
 use action_messages::{ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ExecutionMetadata};
 use common::{encode_stream_proto, fs, DigestInfo};
-use config::cas_server::{LocalWorkerConfig, WrokerProperty};
+use config::cas_server::{LocalWorkerConfig, WorkerProperty};
 use error::{make_err, make_input_err, Code, Error};
 use fast_slow_store::FastSlowStore;
 use filesystem_store::FilesystemStore;
@@ -76,15 +76,15 @@ mod local_worker_tests {
         let mut platform_properties = HashMap::new();
         platform_properties.insert(
             "foo".to_string(),
-            WrokerProperty::values(vec!["bar1".to_string(), "bar2".to_string()]),
+            WorkerProperty::values(vec!["bar1".to_string(), "bar2".to_string()]),
         );
         platform_properties.insert(
             "baz".to_string(),
             // Note: new lines will result in two entries for same key.
             #[cfg(target_family = "unix")]
-            WrokerProperty::query_cmd("echo -e 'hello\ngoodbye'".to_string()),
+            WorkerProperty::query_cmd("echo -e 'hello\ngoodbye'".to_string()),
             #[cfg(target_family = "windows")]
-            WrokerProperty::query_cmd("cmd /C \"echo hello && echo goodbye\"".to_string()),
+            WorkerProperty::query_cmd("cmd /C \"echo hello && echo goodbye\"".to_string()),
         );
         let mut test_context = setup_local_worker(platform_properties).await;
         let streaming_response = test_context.maybe_streaming_response.take().unwrap();

--- a/cas/worker/tests/utils/local_worker_test_utils.rs
+++ b/cas/worker/tests/utils/local_worker_test_utils.rs
@@ -26,7 +26,7 @@ use tonic::{
 };
 
 use common::JoinHandleDropGuard;
-use config::cas_server::{EndpointConfig, LocalWorkerConfig, WrokerProperty};
+use config::cas_server::{EndpointConfig, LocalWorkerConfig, WorkerProperty};
 use error::Error;
 use local_worker::LocalWorker;
 use mock_running_actions_manager::MockRunningActionsManager;
@@ -68,7 +68,7 @@ pub async fn setup_local_worker_with_config(local_worker_config: LocalWorkerConf
     }
 }
 
-pub async fn setup_local_worker(platform_properties: HashMap<String, WrokerProperty>) -> TestContext {
+pub async fn setup_local_worker(platform_properties: HashMap<String, WorkerProperty>) -> TestContext {
     const ARBITRARY_LARGE_TIMEOUT: f32 = 10000.;
     let local_worker_config = LocalWorkerConfig {
         platform_properties,

--- a/cas/worker/worker_utils.rs
+++ b/cas/worker/worker_utils.rs
@@ -22,19 +22,19 @@ use futures::future::try_join_all;
 use tokio::process;
 
 use common::log;
-use config::cas_server::WrokerProperty;
+use config::cas_server::WorkerProperty;
 use error::{make_err, make_input_err, Error, ResultExt};
 use proto::build::bazel::remote::execution::v2::platform::Property;
 use proto::com::github::trace_machina::turbo_cache::remote_execution::SupportedProperties;
 
 pub async fn make_supported_properties<S: BuildHasher>(
-    worker_properties: &HashMap<String, WrokerProperty, S>,
+    worker_properties: &HashMap<String, WorkerProperty, S>,
 ) -> Result<SupportedProperties, Error> {
     let mut futures = vec![];
     for (property_name, worker_property) in worker_properties {
         futures.push(async move {
             match worker_property {
-                WrokerProperty::values(values) => {
+                WorkerProperty::values(values) => {
                     let mut props = Vec::with_capacity(values.len());
                     for value in values {
                         props.push(Property {
@@ -44,7 +44,7 @@ pub async fn make_supported_properties<S: BuildHasher>(
                     }
                     Ok(props)
                 }
-                WrokerProperty::query_cmd(cmd) => {
+                WorkerProperty::query_cmd(cmd) => {
                     let maybe_split_cmd = shlex::split(cmd);
                     let (command, args) = match &maybe_split_cmd {
                         Some(split_cmd) => (&split_cmd[0], &split_cmd[1..]),

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -269,7 +269,7 @@ pub struct ServerConfig {
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
-pub enum WrokerProperty {
+pub enum WorkerProperty {
     /// List of static values.
     /// Note: Generally there should only ever be 1 value, but if the platform
     /// property key is PropertyType::Priority it may have more than one value.
@@ -467,7 +467,7 @@ pub struct LocalWorkerConfig {
     /// Properties of this worker. This configuration will be sent to the scheduler
     /// and used to tell the scheduler to restrict what should be executed on this
     /// worker.
-    pub platform_properties: HashMap<String, WrokerProperty>,
+    pub platform_properties: HashMap<String, WorkerProperty>,
 
     /// An optional script to run before every action is processed on the worker.
     /// The value should be the full path to the script to execute and will pause


### PR DESCRIPTION
# Description

Fixed the typo `WrokerProperty` to `WorkerProperty` in 12 occurrences.
There were no more typos of `Worker` besides this one.

Fixes #390 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran all tests individually and all together.

## Checklist

- [x] Updated documentation if needed
- [x] Tests added/amended
- [x] `bazel test //...`  passes locally
- [x] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/391)
<!-- Reviewable:end -->
