### PR TITLE
Add rustc explicitly to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
             nativeBuildInputs = [
               # Development tooling goes here.
               pkgs.cargo
+              pkgs.rustc
               openssl_static # Required explicitly for cargo test support.
               bazel
             ];


### PR DESCRIPTION
The previous implementation would automatically fetch rustc for cargo
builds. Explicitly add rustc to the flake so that it's version is pinned
and in sync with the cargo package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TraceMachina/turbo-cache/398)
<!-- Reviewable:end -->
